### PR TITLE
Match package.json module path for ESM

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,7 +18,7 @@ const configBase = {
     exclude: 'node_modules/**'
   })],
   output: [
-    getESM({ file: 'dist/unicode-properties.esm.js' }),
+    getESM({ file: 'dist/unicode-properties.es.js' }),
     getCJS({ file: 'dist/unicode-properties.cjs.js' }),
   ]
 }


### PR DESCRIPTION
Fixes this error
```
@parcel/resolver-default: Could not load './dist/unicode-properties.es.js' from module '@react-pdf/unicode-properties' found in package.json#module
/frontend/node_modules/@react-pdf/unicode-properties/package.json
/frontend/node_modules/@react-pdf/unicode-properties/package.json:6:13
  5 |   "main": "dist/unicode-properties.cjs.js",
> 6 |   "module": "dist/unicode-properties.es.js",
>   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ './dist/unicode-properties.es.js' does not exist, did you mean './dist/unicode-properties.esm.js'?'
  7 |   "directories": {
  8 |     "test": "test"
```